### PR TITLE
Load analytics script asynchronously

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -43,7 +43,7 @@
       new EventSource('/changes').addEventListener('change', () => window.location.reload());
     </script>
     {% else %}
-    <script defer src="https://u.frantic.im/script.js" data-website-id="cd2ea49a-5998-477e-8f35-a6ab8d2df514"></script>
+    <script async src="https://u.frantic.im/script.js" data-website-id="cd2ea49a-5998-477e-8f35-a6ab8d2df514"></script>
     {% endif %}
   </body>
 </html>


### PR DESCRIPTION
## Summary
- switch the external analytics loader to use the async attribute so it no longer delays page load

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f45043ec04832a80acce6d1c28352d