### PR TITLE
Fix spelling errors in blog posts

### DIFF
--- a/_posts/2016-06-05-ctrl-r.md
+++ b/_posts/2016-06-05-ctrl-r.md
@@ -14,9 +14,9 @@ If I had to name my favorite most awesome shell shortcut, that would be:
 
 Reverse history search. It's supported by bash, zsh and maybe others. The idea is that you can press `Ctrl+R` and start typing, and the shell will search through every command that you've ever executed that contains given characters, starting from the most recent history record. Press `Ctrl+R` a couple of times while in this mode and the shell will continue the search backwards. Press `Enter` to execute the command as is or any cursor movement keys to edit the command line. `Ctrl+C` will cancel the search and bring you back to normal business.
 
-By itself it doesn't seem like much. However if you think about it, your shell history is a very valuable resourse. For example, do you remember the correct arguments for the `tar` command to compress a folder into tar.gz archive? Me neither. However, if you've done this before at some point, press `Ctrl+R` and type ".gz". Or maybe you forgot the IP address of your Rapsberry Pi? `Ctrl+R`, "ssh " (or even "ssh 192" if you know it's on your local network).
+By itself it doesn't seem like much. However if you think about it, your shell history is a very valuable resource. For example, do you remember the correct arguments for the `tar` command to compress a folder into tar.gz archive? Me neither. However, if you've done this before at some point, press `Ctrl+R` and type ".gz". Or maybe you forgot the IP address of your Raspberry Pi? `Ctrl+R`, "ssh " (or even "ssh 192" if you know it's on your local network).
 
-I learned this approach from Jim Meyering, one of the authors and maintainers of GNU Coreutils. In one of his talks he mentioned he rarely writes shell scrips for one-offs. Instead, it's much easier to write the command directly into the terminal and then search for it when nessesary.
+I learned this approach from Jim Meyering, one of the authors and maintainers of GNU Coreutils. In one of his talks he mentioned he rarely writes shell scripts for one-offs. Instead, it's much easier to write the command directly into the terminal and then search for it when necessary.
 
 `Ctrl+R` is great as it is, however you can make it even more useful by increasing the limit of records your shell keeps in the history file. I have something like this in my shell's rc file:
 

--- a/_posts/2016-07-05-notify-on-completion.md
+++ b/_posts/2016-07-05-notify-on-completion.md
@@ -32,7 +32,7 @@ on run argv
     set frontApp to name of first application process whose frontmost is true
     if frontApp is not "iTerm2" then
       set notifTitle to item 1 of argv
-      set notifBody to "succeded"
+      set notifBody to "succeeded"
       set errorCode to item 2 of argv
       if errorCode is not "0"
         set notifBody to "failed with error code " & errorCode

--- a/_posts/2017-01-18-good-errors-leave-trace.md
+++ b/_posts/2017-01-18-good-errors-leave-trace.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Good Errors Leave Trace
-excerpt: Errors with extra informaton can help locate and fix the problems faster.
+excerpt: Errors with extra information can help locate and fix the problems faster.
 tags:
   - programming
 ---
@@ -42,7 +42,7 @@ For example, for massive scale backend systems it's almost impossible to look at
 
 The nastiest errors happen during error reporting.
 
-When error reporting code tries to be smart and has untrivial amounts of logic, it will inevitably have bugs on its own. Erros while reporting error are the worst, because they usually hide the original cause.
+When error reporting code tries to be smart and has untrivial amounts of logic, it will inevitably have bugs on its own. Errors while reporting error are the worst, because they usually hide the original cause.
 
 Unfortunately they are easy to miss too, because the error path is not usually the common path. The error reporting code gets less coverage in terms of automated and manual tests.
 
@@ -70,7 +70,7 @@ Exception: Error while reporting error
 
 ## Performance
 
-Be aware of the perf cost of including additional information. In particular, often times the error message is formated using some kind of `sprintf` function. Make sure the error message is prepared only when the error has actually been triggered. We had this funny bug in React Native in the early days:
+Be aware of the perf cost of including additional information. In particular, often times the error message is formatted using some kind of `sprintf` function. Make sure the error message is prepared only when the error has actually been triggered. We had this funny bug in React Native in the early days:
 
     invariant(
       VALID[name],

--- a/_posts/2019-06-09-onityper.md
+++ b/_posts/2019-06-09-onityper.md
@@ -34,7 +34,7 @@ Old typewriters don't have this problem: there's no distractions and no way to e
 
 ## Implementation
 
-On my last birthday I got a tiny device, [Onion Omega 2+](https://amzn.to/2MAM80B). It's like Rapsberry Pi, runs Linux, but built on different architecture and has its own set of accessories. It came with 21x7 chars OLED display extension.
+On my last birthday I got a tiny device, [Onion Omega 2+](https://amzn.to/2MAM80B). It's like Raspberry Pi, runs Linux, but built on different architecture and has its own set of accessories. It came with 21x7 chars OLED display extension.
 
 <div class="fig">
   <img src="/assets/onityper/omega.jpg">

--- a/_posts/2019-12-15-how-not-to-flux-set-actions.md
+++ b/_posts/2019-12-15-how-not-to-flux-set-actions.md
@@ -101,7 +101,7 @@ function reducer(state, action) {
 
 Note that the React component in this case doesn't care how this event is handled, it just tells the system about what happened.
 
-The reducer tests in this case are more meaningful, capturing the essense of the business logic:
+The reducer tests in this case are more meaningful, capturing the essence of the business logic:
 
 ```javascript
 test("INCREMENT action", () => {
@@ -122,4 +122,4 @@ Examples:
 
 ---
 
-P.S. The "no `SET_*` actions" rule can be generalized: actions should not be derrived from state. If you need some information from state to construct an action, it's a sign that the action should be simpler and the computation you are trying to perform should probably live in the reducer.
+P.S. The "no `SET_*` actions" rule can be generalized: actions should not be derived from state. If you need some information from state to construct an action, it's a sign that the action should be simpler and the computation you are trying to perform should probably live in the reducer.

--- a/_posts/2021-02-23-octave.im.md
+++ b/_posts/2021-02-23-octave.im.md
@@ -9,7 +9,7 @@ tags:
 
 It all started around 2013: I was going through a course on [Machine Learning by Andrew Ng](https://www.coursera.org/learn/machine-learning).
 
-The practical part of the course depended on GNU Octave (open source math toolkit), but installing it on a Mac was a huge pain. I did manage to do it, but noticed that many people on forums complanied about the same thing.
+The practical part of the course depended on GNU Octave (open source math toolkit), but installing it on a Mac was a huge pain. I did manage to do it, but noticed that many people on forums complained about the same thing.
 
 So I had a brilliant idea — wouldn't it be great if Octave was available via SaaS model? With fancy features like built in code editor, command line and plots?
 

--- a/_posts/2021-03-11-react-api-evolution.md
+++ b/_posts/2021-03-11-react-api-evolution.md
@@ -51,7 +51,7 @@ Initeresting things to note here:
 2. `React.createClass` was used to create a component. I think in hindsight naming it `Class` and not `Component` was a big marketing mistake: with ES6 classes many people were pushing for React to adopt the "standard" way, although it had a lot of problems (more on that later).
 3. In development, React performed `props` validation at runtime (Flow and TypeScript didn't exist back then), and the `PropTypes` API allowed for pretty complex definitions with nested objects and arrays.
 4. Initially, without `React.autoBind` the methods on the components had dynamically scoped `this`, which was pretty confusing: calling `this.tick` would result in something like "Can't call `setState` of unndefined". `autoBind` was doing something like `fn.bind(this)` to fix it on per-function basis, and eventually this behavior was moved directly into `React.createClass`.
-5. React focused on a pure, functional, declarative approach to bulding UIs, but also had escape hatches that allowed programmers take imperative actions or talk to DOM when needed via lifecycle methods and refs.
+5. React focused on a pure, functional, declarative approach to building UIs, but also had escape hatches that allowed programmers take imperative actions or talk to DOM when needed via lifecycle methods and refs.
 
 If you look carefully at the example above, you'll notice that there's a memory leak! We `setInterval` without `clearInterval`-ing it. To fix the problem we'd have to call `clearInterval` from `componentWillUnmount`, however that wasn't obvious from the APIs and programmers had to watch out for patterns like this.
 
@@ -96,7 +96,7 @@ var TickTock = React.createClass({
 
 The code above fixes the memory leak and makes it easier to avoid this problem in the future: just include `SetIntervalMixin` and you are good to go!
 
-Mixins fixed some problems, but intruduced others: implicit dependencies, name clashes and snowballing complexities. [Read more on the official blog post (2016)](https://reactjs.org/blog/2016/07/13/mixins-considered-harmful.html).
+Mixins fixed some problems, but introduced others: implicit dependencies, name clashes and snowballing complexities. [Read more on the official blog post (2016)](https://reactjs.org/blog/2016/07/13/mixins-considered-harmful.html).
 
 ## 2015, [React v0.13](https://reactjs.org/blog/2015/01/27/react-v0.13.0-beta-1.html): `class extends React.Component`
 
@@ -171,7 +171,7 @@ class Timer extends React.Component {
 
 ### Higher-order components
 
-As mixing were goin away, the developers needed to fill the gap: find a way to reuse common functionality across components.
+As mixing were going away, the developers needed to fill the gap: find a way to reuse common functionality across components.
 
 HoC became a popular replacement for mixins. You can think of the pattern as writing a function that takes a component as its argument, and returns a new component that wraps it with some useful enhancement.
 
@@ -228,7 +228,7 @@ HoC promise is to use functional composition to solve the trait problem. But the
 
 ### Render props
 
-React community kept looking for better ways to reuse logic in components and for some time a pattern called "render props" gained a bunch of popularity. I'm not going to dive into these dark ages, but the idea was similar to HoC.
+React community kept looking for better ways to reuse logic in components and for some time a pattern called "render props" gained a bunch of popularity. I'm not goingg to dive into these dark ages, but the idea was similar to HoC.
 
 ## 2019, [React v16.8](https://reactjs.org/blog/2019/02/06/react-v16.8.0.html): Hooks
 
@@ -295,7 +295,7 @@ function Timer(props) {
 }
 ```
 
-But hooks were not without problems either: in the example above there's a subtle problem with the callback we pass to `useInterval`: since it's a new referance every time (in JS, `() => {}` !== `() => {}`) we end up re-creating interval every render. The solution looks like this:
+But hooks were not without problems either: in the example above there's a subtle problem with the callback we pass to `useInterval`: since it's a new reference every time (in JS, `() => {}` !== `() => {}`) we end up re-creating interval every render. The solution looks like this:
 
 ```js
 function Timer(props) {

--- a/_posts/2023-03-27-disposable-software.md
+++ b/_posts/2023-03-27-disposable-software.md
@@ -7,13 +7,13 @@ excerpt: Questioning the status quo of software maintenance
 
 Few weeks ago my microwave stopped working. I called several repair shops and they all told me the same thing: "just buy a new one, it's cheaper than what we'll charge for fixing it".
 
-Maintaining software projects costs a lot of money. Thousands of books have been written on "clean code" and "best practices", all focused on driving the maintanance costs down. Every company or team I worked on has a similar story: "we built this prototype in just a few weeks, but now it's a mess and we can't add new features". Building something new is fun, maintaining old legacy systems is not fun.
+Maintaining software projects costs a lot of money. Thousands of books have been written on "clean code" and "best practices", all focused on driving the maintenance costs down. Every company or team I worked on has a similar story: "we built this prototype in just a few weeks, but now it's a mess and we can't add new features". Building something new is fun, maintaining old legacy systems is not fun.
 
-To add to the problem, businesses don't understand the maintanance costs. After you ship a feature, the business considers it "done". If you want to address tech debt, systematic bugs, refactorings, library upgrades, etc. it takes a lot of explanations and convincing. And even if you manage to get the budget, it's not a priority. The business likes to ship new features, not maintain the old ones.
+To add to the problem, businesses don't understand the maintenance costs. After you ship a feature, the business considers it "done". If you want to address tech debt, systematic bugs, refactorings, library upgrades, etc. it takes a lot of explanations and convincing. And even if you manage to get the budget, it's not a priority. The business likes to ship new features, not maintain the old ones.
 
-But what if there was a magic tool. A tool that could build an app for your from scratch every time something about buisness domain changes. And it will use the latest libraries, latest best practices, hottest programming language. And it will be fast (minutes) and cheap (few dollars worth of GPU time).
+But what if there was a magic tool. A tool that could build an app for your from scratch every time something about business domain changes. And it will use the latest libraries, latest best practices, hottest programming language. And it will be fast (minutes) and cheap (few dollars worth of GPU time).
 
-What would the world look like if we got rid of software maintanance costs?
+What would the world look like if we got rid of software maintenance costs?
 
 --
 

--- a/_posts/2023-06-29-javascript-gom-jabbar.md
+++ b/_posts/2023-06-29-javascript-gom-jabbar.md
@@ -17,7 +17,7 @@ Both `main` and `browser` fields are present, you sense traces of Isomorphic Jav
 
 The `type` is set to `module`. This has something to do with the migration from `requires` to `imports`. Why do we have to care about this, again? The extensive pain you've experienced trying to importing ES5 modules from ESM modules and vice versa overwhelms you again.
 
-You make your way to `scripts`. What a hot, painful mess it is. You can't look at them without your heart rate going to 150. lint, lintall, lintfast, lintdiff. Parallel runs, obscure arguments, double-escaping JSON-formatted arguments. Subcommands calling npm even through you switched to yarn and then pnpm. Thousands of variations, premutations and details make you shiver. Why do these things have to be here? Why do they need to be so complicated?
+You make your way to `scripts`. What a hot, painful mess it is. You can't look at them without your heart rate going to 150. lint, lintall, lintfast, lintdiff. Parallel runs, obscure arguments, double-escaping JSON-formatted arguments. Subcommands calling npm even through you switched to yarn and then pnpm. Thousands of variations, permutations and details make you shiver. Why do these things have to be here? Why do they need to be so complicated?
 
 Some scripts still use `watchman`. Gotta remember to not use symlinks because it doesn't support them (and the issue has been open since 2015). There's also this gulp-based script that nobody has the guts to replace with anything else that's considered more modern. You think that there's actually no modern version of gulp but it feels outdated and you definitely want to get rid of it. The pains spreads from your head into your neck and shoulders.
 
@@ -33,7 +33,7 @@ The next thing in this damn file is `resolutions`. Yes, you remember this one. I
 
 You scroll down to `devDependencies`. You can't remember the time when you only needed non-dev dependencies. Why do we have this split? Yes, right, to cause more pain.
 
-`eslint`. Its configuration got so strict that you can't even write code anymore. Any small misstep and you get an angry red underline. Your CI is configured to treat any lint problem as the end of the world. It gives a false sense of security to your junior engineers on the team. You survived serveral holy wars on which rules to enable. The pain is proportional to the amount of `eslint-ignore`s you have all over your codebase. There's a lot.
+`eslint`. Its configuration got so strict that you can't even write code anymore. Any small misstep and you get an angry red underline. Your CI is configured to treat any lint problem as the end of the world. It gives a false sense of security to your junior engineers on the team. You survived several holy wars on which rules to enable. The pain is proportional to the amount of `eslint-ignore`s you have all over your codebase. There's a lot.
 
 You also notice `postcss` hiding there. This package is a mystery to you. You don't use it directly, it's a requirement of a dependency of a dependency. But it's the package that's constantly causing you pain by throwing obscure C++ compilation errors on any new platform you try to `npm install` on. If CSS itself wasn't painful enough.
 

--- a/_posts/2023-07-04-story-behind-hackathon-photo.md
+++ b/_posts/2023-07-04-story-behind-hackathon-photo.md
@@ -36,7 +36,7 @@ I forgot about this for a while, until several months later I got an email from 
 
 They sent me a bunch of cool prizes: PeakDesign Messenger bag, straps and clips, Moment lens for iPhone, and even a printed version of my photo.
 
-Now, looking at it, I do regret not processing the picture more: the horizon line is a bit tilted, you can spot chromatic abberation, the windows are overexposed.
+Now, looking at it, I do regret not processing the picture more: the horizon line is a bit tilted, you can spot chromatic aberration, the windows are overexposed.
 
 Today that picture has 57 million views and used all over the internet. It even ended up on [Hacker News](https://news.ycombinator.com/item?id=21010674) with the classic "It looks like a sweatshop" and "exact type of workplace I wouldn't want anyone to end up" comments.
 

--- a/_posts/2023-10-29-hacker-gifts.md
+++ b/_posts/2023-10-29-hacker-gifts.md
@@ -2,7 +2,7 @@
 layout: post
 title: "A Side Project Story: Hacker Gifts"
 image: /figma/og_hacker_gifts.png
-excerpt: This is a story about a side project that I started in 2018, and the reasons I'm shuting it down.
+excerpt: This is a story about a side project that I started in 2018, and the reasons I'm shutting it down.
 tags:
   - projects
 ---

--- a/_posts/2024-01-06-opening-mail.md
+++ b/_posts/2024-01-06-opening-mail.md
@@ -19,7 +19,7 @@ It's well-made, affordable, and feels good to use. Plus, it's safe.
 
 The best part? It actually made me enjoy opening my mail.
 
-After this experience, I started thinking differently about unpleasent tasks. Is there a tool or a service that add delight to mundane things?
+After this experience, I started thinking differently about unpleasant tasks. Is there a tool or a service that add delight to mundane things?
 
 I also started noticing when people do this subconiously. For example, most software engineers I know hate blogging, but they like building their own blog engine to make blogging more pleasant (I'm very guilty of this too).
 

--- a/_posts/2025-01-28-hn-stack.md
+++ b/_posts/2025-01-28-hn-stack.md
@@ -9,7 +9,7 @@ tags:
 
 If you want to build a web app The Hacker News Way, here's the stack you should use:
 
-- **Rust** -- the only language that gives you the priviledge of calling your app _"blazing fast"_. According to the undocumented Hacker News rules, any post mentioning Rust in the title starts with 10 points.
+- **Rust** -- the only language that gives you the privilege of calling your app _"blazing fast"_. According to the undocumented Hacker News rules, any post mentioning Rust in the title starts with 10 points.
 - **Postgres** -- the most beloved database that can do absolutely everything: manage data, handle row-level authorization, run job queues, replace Redis, vacuum your apartment (or its own tables… who cares?). No ORMs allowed.
 - **HTMX** -- because JavaScript is obviously the worst part about web development. Bonus points: you get to call yourself the [CEO of HTMX](https://htmx.org/essays/lore/#htmx-ceo), very helpful in this turbulent job market.
 - **Hetzner** -- for just $4.59/mo you can get a server that can easily handle HN's famous [hug-of-death](https://news.ycombinator.com/item?id=20147951).
@@ -18,4 +18,4 @@ Make sure you build your app while WFH, commuting to the office was invented by 
 
 ...
 
-If this post made your simle, maybe you should cut down on reading Hacker News. I know I should.
+If this post made your smile, maybe you should cut down on reading Hacker News. I know I should.


### PR DESCRIPTION
## Summary
- Corrected spelling mistakes across multiple posts in the `_posts` directory
- Updated wording while preserving original context and intent

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938654ba288832aa785bf49202eeee9)